### PR TITLE
Dot- and dict-syntax, create model classes at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Compatible with Python 2 and 3.
 
 ## Breaking changes between v0.x and v1.x
 Version v1.x uses TBA API v3 for data gathering. The API has several major changes which are reflected in this library. Below are a list of potentially breaking changes that were made to this library for compatibility with API v3. If you need to use the old API, simply install and use an older version.
-* The library now functions based on objects rather than raw JSON data. If you still want to use raw JSON data, append `.json` to the end of the object variable. So, if you had a `Team` object named `my_team`, `my_team.json` would give you the team data as a raw dictionary. Otherwise, you'll need to switch to using dot notation for the most part and treating the data appropriately.
+* The library now functions based on objects rather than raw JSON data. Dictionary syntax (ie `team['team_number']`) will work, but object syntax (`team.team_number`) is recommended. If you want to use raw JSON data, append `.json` to the end of the object variable. So, if you had a `Team` object named `my_team`, `my_team.json` would give you the team data as a raw dictionary. Otherwise, you'll need to switch to using dot notation for the most part and treating the data appropriately.
 * Since API v3 now needs an `X-TBA-Auth-Key` header instead of `X-TBA-App-Id`, thus you will need to pass an auth key when instantiating the library rather than an app ID as previously.
 * Team History requests have been renamed to reflect the change in TBA's naming of those requests. `team_history_events()`, `team_history_awards()`, `team_history_robots()`, and `team_history_districts()` have been renamed to `team_events()`, `team_awards()`, `team_robots()`, and `team_districts()`.
 * The `year` parameter in `team_media()` is no longer optional.
@@ -72,7 +72,7 @@ See `example.py` for several usage examples.
 Documentation for The Blue Alliance's API can be found [here](https://www.thebluealliance.com/apidocs).
 
 ## Authors
-This software was created and is maintained by [Erik Boesen](https://github.com/ErikBoesen) with [Team 1418](https://github.com/frc1418).
+This software was created and is maintained by [Erik Boesen](https://github.com/ErikBoesen) with [Team 1418](https://github.com/frc1418). Additional contributions made by [Ian Weiss](https://github.com/endreman0) with [Team 4131](https://github.com/FRC4131).
 
 ## License
 This software is protected under the [MIT License](LICENSE).

--- a/example.py
+++ b/example.py
@@ -11,7 +11,9 @@ match = tba.match(year=2017,
                   type='sf',
                   number=2,
                   round=1)
+robots = tba.team_robots(4131)
 
 print('Team 254 is from %s in %s, %s.' % (team.city, team.state_prov, team.country))
 print('Team 1418 is/was in the %s district in the most recent year of competition.' % districts[-1].display_name)
 print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match.predicted_time)
+print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot.robot_name, robot.year) for robot in robots))

--- a/example.py
+++ b/example.py
@@ -13,7 +13,22 @@ match = tba.match(year=2017,
                   round=1)
 robots = tba.team_robots(4131)
 
+print('-' * 10 + ' Object Syntax' + '-' * 10)
 print('Team 254 is from %s in %s, %s.' % (team.city, team.state_prov, team.country))
 print('Team 1418 is/was in the %s district in the most recent year of competition.' % districts[-1].display_name)
 print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match.predicted_time)
 print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot.robot_name, robot.year) for robot in robots))
+print()
+
+print('-' * 8 + ' Dictionary Syntax' + '-' * 8)
+print('Team 254 is from %s in %s, %s.' % (team['city'], team['state_prov'], team['country']))
+print('Team 1418 is/was in the %s district in the most recent year of competition.' % districts[-1]['display_name'])
+print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match['predicted_time'])
+print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot['robot_name'], robot['year']) for robot in robots))
+print()
+
+print('-' * 5 + ' .json Dictionary Syntax' + '-' * 5)
+print('Team 254 is from %s in %s, %s.' % (team.json['city'], team.json['state_prov'], team.json['country']))
+print('Team 1418 is/was in the %s district in the most recent year of competition.' % districts[-1].json['display_name'])
+print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match.json['predicted_time'])
+print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot.json['robot_name'], robot.json['year']) for robot in robots))

--- a/tbapy/models.py
+++ b/tbapy/models.py
@@ -1,178 +1,41 @@
-class Team:
-    def __init__(self, json):
-        self.json = json
-        self.address = json['address']
-        self.city = json['city']
-        self.country = json['country']
-        self.gmaps_place_id = json['gmaps_place_id']
-        self.gmaps_url = json['gmaps_url']
-        self.home_championship = json['home_championship']
-        self.key = json['key']
-        self.lat = json['lat']
-        self.lng = json['lng']
-        self.location_name = json['location_name']
-        self.motto = json['motto']
-        self.name = json['name']
-        self.nickname = json['nickname']
-        self.postal_code = json['postal_code']
-        self.rookie_year = json['rookie_year']
-        self.state_prov = json['state_prov']
-        self.team_number = json['team_number']
-        self.website = json['website']
+def _create_model_class(class_name, *json_keys):
+    def init(self, json):
+    self.json = json
+    for key in json_keys:
+    setattr(self, key, json[key])
+    return type(class_name, (), {'__init__': init})
 
+Team = _create_model_class('Team', 'address', 'city', 'country', 'gmaps_place_id', 'gmaps_url', 'home_championship', 'key', 'lat', 'lng',
+                           'location_name', 'motto', 'name', 'nickname', 'postal_code', 'rookie_year', 'state_prov', 'team_number', 'website')
 
-class Event:
-    def __init__(self, json):
-        self.json = json
-        self.address = json['address']
-        self.city = json['city']
-        self.country = json['country']
-        self.district = json['district']
-        self.division_keys = json['division_keys']
-        self.end_date = json['end_date']
-        self.event_code = json['event_code']
-        self.event_type = json['event_type']
-        self.event_type_string = json['event_type_string']
-        self.first_event_id = json['first_event_id']
-        self.gmaps_place_id = json['gmaps_place_id']
-        self.gmaps_url = json['gmaps_url']
-        self.key = json['key']
-        self.lat = json['lat']
-        self.lng = json['lng']
-        self.location_name = json['location_name']
-        self.name = json['name']
-        self.parent_event_key = json['parent_event_key']
-        self.playoff_type = json['playoff_type']
-        self.playoff_type_string = json['playoff_type_string']
-        self.postal_code = json['postal_code']
-        self.short_name = json['short_name']
-        self.start_date = json['start_date']
-        self.state_prov = json['state_prov']
-        self.timezone = json['timezone']
-        self.webcasts = json['webcasts']
-        self.website = json['website']
-        self.week = json['week']
-        self.year = json['year']
+Event = _create_model_class('Event', 'address', 'city', 'country', 'district', 'division_keys', 'end_date', 'event_code', 'event_type',
+                            'event_type_string', 'first_event_id', 'gmaps_place_id', 'gmaps_url', 'key', 'lat', 'lng', 'location_name', 'name',
+                            'parent_event_key', 'playoff_type', 'playoff_type_string', 'postal_code', 'short_name', 'start_date', 'state_prov',
+                            'timezone', 'webcasts', 'website', 'week', 'year')
 
+Match = _create_model_class('Match', 'actual_time', 'alliances', 'comp_level', 'event_key', 'key', 'match_number', 'post_result_time',
+                            'predicted_time', 'score_breakdown', 'set_number', 'time', 'videos', 'winning_alliance')
 
-class Match:
-    def __init__(self, json):
-        self.json = json
-        self.actual_time = json['actual_time']
-        self.alliances = json['alliances']
-        self.comp_level = json['comp_level']
-        self.event_key = json['event_key']
-        self.key = json['key']
-        self.match_number = json['match_number']
-        self.post_result_time = json['post_result_time']
-        self.predicted_time = json['predicted_time']
-        self.score_breakdown = json['score_breakdown']
-        self.set_number = json['set_number']
-        self.time = json['time']
-        self.videos = json['videos']
-        self.winning_alliance = json['winning_alliance']
+Award = _create_model_class('Award', 'award_type', 'event_key', 'name', 'recipient_list', 'year')
 
+District = _create_model_class('District', 'abbreviation', 'display_name', 'key', 'year')
 
-class Award:
-    def __init__(self, json):
-        self.json = json
-        self.award_type = json['award_type']
-        self.event_key = json['event_key']
-        self.name = json['name']
-        self.recipient_list = json['recipient_list']
-        self.year = json['year']
+Media = _create_model_class('Media', 'details', 'foreign_key', 'preferred', 'type')
 
+Robot = _create_model_class('Robot', 'key', 'robot_name', 'team_key', 'year')
 
-class District:
-    def __init__(self, json):
-        self.json = json
-        self.abbreviation = json['abbreviation']
-        self.display_name = json['display_name']
-        self.key = json['key']
-        self.year = json['year']
+Profile = _create_model_class('Profile', 'details', 'preferred', 'type')
 
+Alliance = _create_model_class('Alliance', 'backup', 'declines', 'name', 'picks', 'status')
 
-class Media:
-    def __init__(self, json):
-        self.json = json
-        self.details = json['details']
-        self.foreign_key = json['foreign_key']
-        self.preferred = json['preferred']
-        self.type = json['type']
+DistrictPoints = _create_model_class('DistrictPoints', 'extra_stats_info', 'rankings', 'sort_order_info')
 
-class Robot:
-    def __init__(self, json):
-        self.json = json
-        self.key = json['key']
-        self.robot_name = json['robot_name']
-        self.team_key = json['team_key']
-        self.year = json['year']
+Insights = _create_model_class('Insights', 'playoff', 'qual')
 
+OPRs = _create_model_class('OPRs', 'ccwms', 'dprs', 'oprs')
 
-class Profile:
-    def __init__(self, json):
-        self.json = json
-        self.details = json['details']
-        self.preferred = json['preferred']
-        self.type = json['type']
+Prediction = _create_model_class('Prediction', 'match_prediction_stats', 'match_predictions', 'ranking_prediction_stats',
+                                 'ranking_predictions', 'stat_mean_vars')
+Rankings = _create_model_class('Rankings', 'extra_stats_info', 'rankings', 'sort_order_info')
 
-
-class Alliance:
-    def __init__(self, json):
-        self.json = json
-        self.backup = json['backup']
-        self.declines = json['declines']
-        self.name = json['name']
-        self.picks = json['picks']
-        self.status = json['status']
-
-
-class DistrictPoints:
-    def __init__(self, json):
-        self.json = json
-        self.extra_stats_info = json['extra_stats_info']
-        self.rankings = json['rankings']
-        self.sort_order_info = json['sort_order_info']
-
-
-class Insights:
-    def __init__(self, json):
-        self.json = json
-        self.playoff = json['playoff']
-        self.qual = json['qual']
-
-
-class OPRs:
-    def __init__(self, json):
-        self.json = json
-        self.ccwms = json['ccwms']
-        self.dprs = json['dprs']
-        self.oprs = json['oprs']
-
-
-class Prediction:
-    def __init__(self, json):
-        self.json = json
-        self.match_prediction_stats = json['match_prediction_stats']
-        self.match_predictions = json['match_predictions']
-        self.ranking_prediction_stats = json['ranking_prediction_stats']
-        self.ranking_predictions = json['ranking_predictions']
-        self.stat_mean_vars = json['stat_mean_vars']
-
-
-class Rankings:
-    def __init__(self, json):
-        self.json = json
-        self.extra_stats_info = json['extra_stats_info']
-        self.rankings = json['rankings']
-        self.sort_order_info = json['sort_order_info']
-
-
-class DistrictRanking:
-    def __init__(self, json):
-        self.json = json
-        self.event_points = json['event_points']  # TODO: Expand this.
-        self.point_total = json['point_total']
-        self.rank = json['rank']
-        self.rookie_bonus = json['rookie_bonus']
-        self.team_key = json['team_key']
+DistrictRanking = _create_model_class('DistrictRanking', 'event_points', 'point_total', 'rank', 'rookie_bonus', 'team_key')

--- a/tbapy/models.py
+++ b/tbapy/models.py
@@ -1,49 +1,29 @@
 class _base_model_class(dict):
-    def __getitem__(self, item):
-        try:
-            return getattr(self, item)
-        except AttributeError:
-            raise KeyError(item)
-
-def _create_model_class(class_name, *json_keys):
-    def init(self, json):
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+    def __init__(self, json):
         self.json = json
         self.update(json)
-        for key in json_keys:
-            setattr(self, key, json[key])
-    return type(class_name, (_base_model_class,), {'__init__': init})
+    def __repr__(self):
+        contents = {k: self[k] for k in self if k != 'json'} # Exclude :json: from the string
+        return '%s(%s)' % (self.__class__.__name__, dict.__repr__(contents))
 
-Team = _create_model_class('Team', 'address', 'city', 'country', 'gmaps_place_id', 'gmaps_url', 'home_championship', 'key', 'lat', 'lng',
-                           'location_name', 'motto', 'name', 'nickname', 'postal_code', 'rookie_year', 'state_prov', 'team_number', 'website')
+def _model_class(class_name):
+    return type(class_name, (_base_model_class,), {})
 
-Event = _create_model_class('Event', 'address', 'city', 'country', 'district', 'division_keys', 'end_date', 'event_code', 'event_type',
-                            'event_type_string', 'first_event_id', 'gmaps_place_id', 'gmaps_url', 'key', 'lat', 'lng', 'location_name', 'name',
-                            'parent_event_key', 'playoff_type', 'playoff_type_string', 'postal_code', 'short_name', 'start_date', 'state_prov',
-                            'timezone', 'webcasts', 'website', 'week', 'year')
-
-Match = _create_model_class('Match', 'actual_time', 'alliances', 'comp_level', 'event_key', 'key', 'match_number', 'post_result_time',
-                            'predicted_time', 'score_breakdown', 'set_number', 'time', 'videos', 'winning_alliance')
-
-Award = _create_model_class('Award', 'award_type', 'event_key', 'name', 'recipient_list', 'year')
-
-District = _create_model_class('District', 'abbreviation', 'display_name', 'key', 'year')
-
-Media = _create_model_class('Media', 'details', 'foreign_key', 'preferred', 'type')
-
-Robot = _create_model_class('Robot', 'key', 'robot_name', 'team_key', 'year')
-
-Profile = _create_model_class('Profile', 'details', 'preferred', 'type')
-
-Alliance = _create_model_class('Alliance', 'backup', 'declines', 'name', 'picks', 'status')
-
-DistrictPoints = _create_model_class('DistrictPoints', 'extra_stats_info', 'rankings', 'sort_order_info')
-
-Insights = _create_model_class('Insights', 'playoff', 'qual')
-
-OPRs = _create_model_class('OPRs', 'ccwms', 'dprs', 'oprs')
-
-Prediction = _create_model_class('Prediction', 'match_prediction_stats', 'match_predictions', 'ranking_prediction_stats',
-                                 'ranking_predictions', 'stat_mean_vars')
-Rankings = _create_model_class('Rankings', 'extra_stats_info', 'rankings', 'sort_order_info')
-
-DistrictRanking = _create_model_class('DistrictRanking', 'event_points', 'point_total', 'rank', 'rookie_bonus', 'team_key')
+Team = _model_class('Team')
+Event = _model_class('Event')
+Match = _model_class('Match')
+Award = _model_class('Award')
+District = _model_class('District')
+Media = _model_class('Media')
+Robot = _model_class('Robot')
+Profile = _model_class('Profile')
+Alliance = _model_class('Alliance')
+DistrictPoints = _model_class('DistrictPoints')
+Insights = _model_class('Insights')
+OPRs = _model_class('OPRs')
+Prediction = _model_class('Prediction')
+Rankings = _model_class('Rankings')
+DistrictRanking = _model_class('DistrictRanking')

--- a/tbapy/models.py
+++ b/tbapy/models.py
@@ -1,9 +1,17 @@
+class _base_model_class(dict):
+    def __getitem__(self, item):
+        try:
+            return getattr(self, item)
+        except AttributeError:
+            raise KeyError(item)
+
 def _create_model_class(class_name, *json_keys):
     def init(self, json):
-    self.json = json
-    for key in json_keys:
-    setattr(self, key, json[key])
-    return type(class_name, (), {'__init__': init})
+        self.json = json
+        self.update(json)
+        for key in json_keys:
+            setattr(self, key, json[key])
+    return type(class_name, (_base_model_class,), {'__init__': init})
 
 Team = _create_model_class('Team', 'address', 'city', 'country', 'gmaps_place_id', 'gmaps_url', 'home_championship', 'key', 'lat', 'lng',
                            'location_name', 'motto', 'name', 'nickname', 'postal_code', 'rookie_year', 'state_prov', 'team_number', 'website')


### PR DESCRIPTION
- Allow dot-syntax and dict-syntax for all model classes. All classes inherit from `dict`, so they get all of the other benefits like iterating over keys, `get()`, etc.
- Create model classes dynamically, and create their keys dynamically as well. All of the repetition is gone from `models.py`, and the big list of keys in the first commit is gone too. Adding a model class is now just a call to `_model_class(class_name)`.
- Add dict-syntax and `.json` syntax to examples.
- `str(x)` and `repr(x)` now show the model's class name, followed by its data in parentheses. This was inspired by `frozenset`. The `json` key is excluded.