### PR TITLE
Fix team_events and hasattr support

### DIFF
--- a/example.py
+++ b/example.py
@@ -11,12 +11,14 @@ match = tba.match(year=2017,
                   type='sf',
                   number=2,
                   round=1)
+events = tba.team_events(148, 2016)
 robots = tba.team_robots(4131)
 
 print('-' * 10 + ' Object Syntax' + '-' * 10)
 print('Team 254 is from %s in %s, %s.' % (team.city, team.state_prov, team.country))
 print('Team 1418 is/was in the %s district in the most recent year of competition.' % districts[-1].display_name)
 print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match.predicted_time)
+print('In 2016, team 148 was in %d events: %s.' % (len(events), ', '.join(event.event_code for event in events)))
 print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot.robot_name, robot.year) for robot in robots))
 print()
 
@@ -24,6 +26,7 @@ print('-' * 8 + ' Dictionary Syntax' + '-' * 8)
 print('Team 254 is from %s in %s, %s.' % (team['city'], team['state_prov'], team['country']))
 print('Team 1418 is/was in the %s district in the most recent year of competition.' % districts[-1]['display_name'])
 print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match['predicted_time'])
+print('In 2016, team 148 was in %d events: %s.' % (len(events), ', '.join(event['event_code'] for event in events)))
 print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot['robot_name'], robot['year']) for robot in robots))
 print()
 
@@ -31,4 +34,5 @@ print('-' * 5 + ' .json Dictionary Syntax' + '-' * 5)
 print('Team 254 is from %s in %s, %s.' % (team.json['city'], team.json['state_prov'], team.json['country']))
 print('Team 1418 is/was in the %s district in the most recent year of competition.' % districts[-1].json['display_name'])
 print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match.json['predicted_time'])
+print('In 2016, team 148 was in %d events: %s.' % (len(events), ', '.join(event.json['event_code'] for event in events)))
 print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot.json['robot_name'], robot.json['year']) for robot in robots))

--- a/example.py
+++ b/example.py
@@ -20,6 +20,8 @@ print('Team 1418 is/was in the %s district in the most recent year of competitio
 print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match.predicted_time)
 print('In 2016, team 148 was in %d events: %s.' % (len(events), ', '.join(event.event_code for event in events)))
 print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot.robot_name, robot.year) for robot in robots))
+print('Robots have attribute name:', hasattr(robots[0], 'name'))
+print('Robots have attribute robot_name:', hasattr(robots[0], 'robot_name'))
 print()
 
 print('-' * 8 + ' Dictionary Syntax' + '-' * 8)
@@ -28,6 +30,8 @@ print('Team 1418 is/was in the %s district in the most recent year of competitio
 print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match['predicted_time'])
 print('In 2016, team 148 was in %d events: %s.' % (len(events), ', '.join(event['event_code'] for event in events)))
 print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot['robot_name'], robot['year']) for robot in robots))
+print('Robots have attribute name:', 'name' in robots[0])
+print('Robots have attribute robot_name:', 'robot_name' in robots[0])
 print()
 
 print('-' * 5 + ' .json Dictionary Syntax' + '-' * 5)
@@ -36,3 +40,5 @@ print('Team 1418 is/was in the %s district in the most recent year of competitio
 print('The second qual match at the 2017 CHS District Championship was predicted to start at Unix Time %s.' % match.json['predicted_time'])
 print('In 2016, team 148 was in %d events: %s.' % (len(events), ', '.join(event.json['event_code'] for event in events)))
 print('Team 4131\'s robots: ' + ', '.join('%s (%d)' % (robot.json['robot_name'], robot.json['year']) for robot in robots))
+print('Robots have attribute name:', 'name' in robots[0].json)
+print('Robots have attribute robot_name:', 'robot_name' in robots[0].json)

--- a/tbapy/main.py
+++ b/tbapy/main.py
@@ -87,9 +87,9 @@ class TBA:
         """
         if year:
             if keys:
-                return self._fetch('team/%s/%s/events/keys' % (self.team_key(team), year))
+                return self._fetch('team/%s/events/%s/keys' % (self.team_key(team), year))
             else:
-                return [Event(raw) for raw in self._fetch('team/%s/%s/events' % (self.team_key(team), year))]
+                return [Event(raw) for raw in self._fetch('team/%s/events/%s' % (self.team_key(team), year))]
         else:
             if keys:
                 return self._fetch('team/%s/events/keys' % self.team_key(team))

--- a/tbapy/models.py
+++ b/tbapy/models.py
@@ -1,10 +1,10 @@
 class _base_model_class(dict):
-    __getattr__ = dict.__getitem__
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
     def __init__(self, json):
         self.json = json
         self.update(json)
+        self.update(self.__dict__)
+        self.__dict__ = self
+        
     def __repr__(self):
         contents = {k: self[k] for k in self if k != 'json'} # Exclude :json: from the string
         return '%s(%s)' % (self.__class__.__name__, dict.__repr__(contents))


### PR DESCRIPTION
Fix \#1: the URL for a team's events a given year is `team/{team}/events/{year}`, with the year after `/events`. Currently calling `tba.team_events(4131)` raises a `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

Fix \#2: the current way of allowing dot-syntax on model classes will raise a KeyError, instead of an AttributeError, if an attribute does not exist. This means `hasattr` will raise the KeyError instead of returning False for nonexistent keys. This new way of allowing dot-syntax works the same as before, except `hasattr` will return False for nonexistent keys.

Both changes have examples in `example.py`.