### PR TITLE
Add simple model to tba.events

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Replace `tba` with the object name if you changed it above.
 * `tba.team_robots(team)` - Get data about a team's robots.
 * `tba.team_districts(team)` - Get the districts that a team has been part of over the years.
 * `tba.team_social_media(team)` - Get data on a team's social media profiles.
-* `tba.events([year], [keys])` - Get a list of all events. _OPTIONAL: Include a year to get events from that year. Otherwise the current year's events will be returned. You may also specify `keys` as True to get only the keys of the events rather than full data._
+* `tba.events([year], [keys], [simple])` - Get a list of all events. _OPTIONAL: Include a year to get events from that year. Otherwise the current year's events will be returned. You may also specify `keys` or 'simple' as True to get only the keys or simple model of the events rather than full data, respectively. If both 'keys' and 'simple' are true, then it will return keys._
 * `tba.event(event, [simple])` - Get data about an event. _OPTIONAL: Specify `simple` as `True` to get simpler data on an event. Recommended unless you need the extra data._
 * `tba.event_alliances(event)` - Get sophisticated data on alliances at a given event.
 * `tba.event_district_points(event)` - Get sophisticated data on district points at a given event.

--- a/tbapy/main.py
+++ b/tbapy/main.py
@@ -187,16 +187,19 @@ class TBA:
         """
         return [Profile(raw) for raw in self._fetch('team/%s/social_media')]
 
-    def events(self, year, keys=False):
+    def events(self, year, keys=False, simple=False):
         """
         Get a list of events in a given year.
 
         :param year: Year to get events from.
         :param keys: Get only keys of the events rather than full data.
+        :param simple: Get the simple model of the events rather than full data.
         :return: List of string event keys of Event objects.
         """
         if keys:
             return self._fetch('events/%s/keys' % year)
+        elif simple:
+            return self._fetch('events/%s/simple' % year)
         else:
             return [Event(raw) for raw in self._fetch('events/%s' % year)]
 


### PR DESCRIPTION
Allows the option of getting the simple models when fetching all of a year's events.