### PR TITLE
Add error if API key is invalid

### DIFF
--- a/tbapy/main.py
+++ b/tbapy/main.py
@@ -20,6 +20,10 @@ class TBA:
         """
         self.auth_key = auth_key
 
+        status = self.status()
+        if 'Error' in status:
+            raise APIKeyError(status['Error'])
+
     def _fetch(self, url):
         """
         Helper method: fetch data from given URL on TBA's API.
@@ -374,3 +378,6 @@ class TBA:
 
     # TODO: Suggest media request.
     # TODO: Use .format() instead of % notation.
+
+class APIKeyError(Exception):
+    pass


### PR DESCRIPTION
Raises a APIKeyError if calling status() with the provided key fails. I don't know if that is the best place for the APIKeyError class.