### PR TITLE
Expand team_status for multiple teams/events

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tbapy',
-      version='1.3.1',
+      version='1.3.3',
       description='Library for interacting with The Blue Alliance API.',
       url='https://github.com/frc1418/tbapy',
       author='FRC Team 1418, Erik Boesen',

--- a/tbapy/main.py
+++ b/tbapy/main.py
@@ -327,16 +327,12 @@ class TBA:
         if event:
             if team:
                 return Status(self._get('team/%s/event/%s/status' % (self.team_key(team), event)))
-            else:
-                return [Status(raw) for raw in self._get('event/%s/teams/statuses' % (event))]
-        else:
-            if year:
-                if team:
-                    return [Status(raw) for raw in self._get('team/%s/events/%s/statuses' % (self.team_key(team), year))]
-                else:
-                    return ValueError('Team must be specified if year is specified.')
-            else:
-                raise ValueError("Must specify either event or year.")
+            return [Status(raw) for raw in self._get('event/%s/teams/statuses' % (event))]
+        if year:
+            if team:
+                return [Status(raw) for raw in self._get('team/%s/events/%s/statuses' % (self.team_key(team), year))]
+            raise ValueError('Team must be specified if year is specified.')
+        raise ValueError('Must specify either event or year.')
 
 
     @_check_modified

--- a/tbapy/main.py
+++ b/tbapy/main.py
@@ -315,15 +315,29 @@ class TBA:
         return [Profile(raw) for raw in self._get('team/%s/social_media' % self.team_key(team))]
 
     @_check_modified
-    def team_status(self, team, event):
+    def team_status(self, team=None, event=None, year=None):
         """
         Get status of a team at an event.
 
         :param team: Team whose status to get.
         :param event: Event team is at.
+        :param year: Year of events to return.
         :return: Status object.
         """
-        return Status(self._get('team/%s/event/%s/status' % (self.team_key(team), event)))
+        if event:
+            if team:
+                return Status(self._get('team/%s/event/%s/status' % (self.team_key(team), event)))
+            else:
+                return [Status(raw) for raw in self._get('event/%s/teams/statuses' % (event))]
+        else:
+            if year:
+                if team:
+                    return [Status(raw) for raw in self._get('team/%s/events/%s/statuses' % (self.team_key(team), year))]
+                else:
+                    return ValueError('Team must be specified if year is specified.')
+            else:
+                raise ValueError("Must specify either event or year.")
+
 
     @_check_modified
     def events(self, year, simple=False, keys=False):


### PR DESCRIPTION
Allow the user to specify an event and get all teams' statuses (via /event/{event_key}/teams/statuses) or specify a team+year and get their statuses for all events (via /team/{team_key}/events/{year}/statuses)